### PR TITLE
Add agent refactor skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@
 ## Demo
 
 You can view a fully working demo at [skedy.io](https://skedy.io/).
+
+## Multi-Intent Refactor
+
+The codebase is being restructured to support multiple intents per user message and a more flexible conversation flow.  Phase 1 introduces a new module skeleton under `src/agent` which will house the future architecture:
+
+```
+src/agent/
+  preprocessor/        // normalizes incoming text
+  context/             // stores conversation history
+  intent-classifier/   // detects multiple intents
+  state-manager/       // tracks active goals and slots
+  tasks/               // intent specific handlers
+  llm-response/        // combines outputs using LLM
+  whatsapp-renderer/   // formats responses for WhatsApp
+```
+
+These folders currently contain placeholder implementations and will be expanded in later phases.

--- a/src/agent/context/index.ts
+++ b/src/agent/context/index.ts
@@ -1,0 +1,18 @@
+export interface ConversationContext {
+  history: string[];
+}
+
+/**
+ * Manages retrieval and update of conversation history.
+ */
+export class ContextManager {
+  private context: ConversationContext = { history: [] };
+
+  addMessage(message: string) {
+    this.context.history.push(message);
+  }
+
+  getContext(): ConversationContext {
+    return this.context;
+  }
+}

--- a/src/agent/intent-classifier/index.ts
+++ b/src/agent/intent-classifier/index.ts
@@ -1,0 +1,13 @@
+export interface DetectedIntent {
+  type: string;
+  entities?: Record<string, string>;
+}
+
+/**
+ * Placeholder multi-intent classifier.
+ */
+export function detectIntents(text: string): DetectedIntent[] {
+  // TODO: Replace with ML model or LLM call
+  if (!text) return [];
+  return [{ type: 'unknown' }];
+}

--- a/src/agent/llm-response/index.ts
+++ b/src/agent/llm-response/index.ts
@@ -1,0 +1,5 @@
+export class ResponseGenerator {
+  generate(responses: string[]): string {
+    return responses.join(' ');
+  }
+}

--- a/src/agent/preprocessor/index.ts
+++ b/src/agent/preprocessor/index.ts
@@ -1,0 +1,14 @@
+export interface PreprocessedMessage {
+  raw: string;
+  normalized: string;
+}
+
+/**
+ * Prepare incoming text for downstream processing.
+ */
+export function preprocessMessage(message: string): PreprocessedMessage {
+  return {
+    raw: message,
+    normalized: message.trim().toLowerCase(),
+  };
+}

--- a/src/agent/state-manager/index.ts
+++ b/src/agent/state-manager/index.ts
@@ -1,0 +1,30 @@
+import { DetectedIntent } from '../intent-classifier';
+
+export interface GoalSlot {
+  name: string;
+  value?: string;
+}
+
+export interface ActiveGoal {
+  type: string;
+  slots: GoalSlot[];
+}
+
+/**
+ * Tracks progress of active conversation goals.
+ */
+export class DialogueStateManager {
+  private goals: ActiveGoal[] = [];
+
+  addGoal(goal: ActiveGoal) {
+    this.goals.push(goal);
+  }
+
+  updateFromIntents(intents: DetectedIntent[]) {
+    // TODO: implement real logic
+  }
+
+  getGoals(): ActiveGoal[] {
+    return this.goals;
+  }
+}

--- a/src/agent/tasks/booking-intent-manager.ts
+++ b/src/agent/tasks/booking-intent-manager.ts
@@ -1,0 +1,8 @@
+import { ActiveGoal } from '../state-manager';
+
+export class BookingIntentManager {
+  handle(goal: ActiveGoal): string {
+    // TODO: booking management logic
+    return 'booking placeholder';
+  }
+}

--- a/src/agent/tasks/chitchat-responder.ts
+++ b/src/agent/tasks/chitchat-responder.ts
@@ -1,0 +1,5 @@
+export class ChitchatResponder {
+  respond(message: string): string {
+    return 'chitchat placeholder';
+  }
+}

--- a/src/agent/tasks/faq-handler.ts
+++ b/src/agent/tasks/faq-handler.ts
@@ -1,0 +1,6 @@
+export class FAQHandler {
+  answer(question: string): string {
+    // TODO: integrate RAG search
+    return 'faq placeholder';
+  }
+}

--- a/src/agent/tasks/index.ts
+++ b/src/agent/tasks/index.ts
@@ -1,0 +1,3 @@
+export * from './booking-intent-manager';
+export * from './faq-handler';
+export * from './chitchat-responder';

--- a/src/agent/whatsapp-renderer/index.ts
+++ b/src/agent/whatsapp-renderer/index.ts
@@ -1,0 +1,4 @@
+export function renderWhatsAppMessage(text: string): string {
+  // Format text for WhatsApp buttons or plain message
+  return text;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
       "@/*": ["./*"],
       "@components/*": ["components/*"],
       "@app/*": ["app/*"],
-      "@lib/*": ["lib/*"]
+      "@lib/*": ["lib/*"],
+      "@agent/*": ["src/agent/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -4,7 +4,8 @@
       "module": "commonjs",
       "baseUrl": ".",
       "paths": {
-        "@/*": ["./*"]
+        "@/*": ["./*"],
+        "@agent/*": ["src/agent/*"]
       }
     },
     "include": [


### PR DESCRIPTION
## Summary
- begin Phase 1 of multi-intent refactor
- create `src/agent` directory with placeholder modules
- add `@agent/*` path aliases
- document new architecture in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: failed to download chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_685117d08c8883228bf5c89e0bd11ab8