### PR TITLE
Add slot-based dialogue state manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,34 @@
 ## Demo
 
 You can view a fully working demo at [skedy.io](https://skedy.io/).
+
+## Multi-Intent Refactor
+
+The codebase is being restructured to support multiple intents per user message and a more flexible conversation flow.  Phase 1 introduces a new module skeleton under `src/agent` which will house the future architecture:
+
+```
+src/agent/
+  preprocessor/        // normalizes incoming text
+  context/             // stores conversation history
+  intent-classifier/   // detects multiple intents
+  state-manager/       // tracks active goals and slots
+  tasks/               // intent specific handlers
+  llm-response/        // combines outputs using LLM
+  whatsapp-renderer/   // formats responses for WhatsApp
+```
+
+These folders currently contain placeholder implementations and will be expanded in later phases.
+
+### Phase 2 – Multi-Intent Detection
+
+`analyzeConversationIntents` replaces the old single-intent analyzer and
+returns a list of detected intents. The orchestrator currently uses the
+first intent for state processing while the rest will be handled in
+future phases.
+
+### Phase 3 – Slot-Based Dialogue State
+
+`DialogueStateManager` introduces a simple goal+slot model. Detected
+intents are converted into goals with slots like `service`, `date` and
+`time` for bookings. The manager updates slot values whenever new
+entities are found so multiple intents can progress in parallel.

--- a/lib/conversation-engine/conversation-orchestrator.ts
+++ b/lib/conversation-engine/conversation-orchestrator.ts
@@ -15,7 +15,7 @@ import { ServiceData } from '../database/models/service';
 import { ParsedMessage } from '../cross-channel-interfaces/standardized-conversation-interface';
 import { UserContext } from '../database/models/user-context';
 import { BotResponse } from '../cross-channel-interfaces/standardized-conversation-interface';
-import { analyzeConversationIntent, AnalyzedIntent } from './llm-actions/chat-interactions/functions/intention-detector';
+import { analyzeConversationIntents, getFallbackIntent, AnalyzedIntent } from './llm-actions/chat-interactions/functions/intention-detector';
 import { processTurn } from './state-manager';
 import { ChatMessage } from '../database/models/chat-session';
 import { OpenAIChatMessage } from './llm-actions/chat-interactions/openai-config/openai-core';
@@ -24,6 +24,7 @@ import { generateAgentResponse } from './llm-actions/llm-response-generator';
 import { Business } from '../database/models/business';
 import { Service } from '../database/models/service';
 import { BookingButtonGenerator } from './flows/bookings/customer-booking-steps';
+import { DialogueStateManager } from '@agent/state-manager';
 
 export interface OrchestratorResult {
     finalBotResponse: BotResponse;
@@ -57,6 +58,8 @@ export async function routeInteraction(
     history: ChatMessage[]
 ): Promise<OrchestratorResult> {
 
+    const newStateManager = new DialogueStateManager();
+
     // A businessId is critical for all subsequent operations.
     const businessId = userContext.businessId;
     if (!businessId) {
@@ -65,7 +68,8 @@ export async function routeInteraction(
         return { finalBotResponse: errorResponse, updatedContext: userContext, history };
     }
 
-    let analyzedIntent: AnalyzedIntent;
+    let detectedIntents: AnalyzedIntent[];
+    let primaryIntent: AnalyzedIntent;
     const userMessage = parsedMessage.text || '';
 
     // --- Intent Detection Bypass Logic ---
@@ -76,22 +80,25 @@ export async function routeInteraction(
 
     if (userMessage && serviceIds.includes(userMessage)) {
         console.log('[Orchestrator] Service ID detected in message. Bypassing LLM intent analysis.');
-        // Manually construct the intent, as we know exactly what the user wants.
-        analyzedIntent = {
+        detectedIntents = [{
             goalType: 'serviceBooking',
             goalAction: 'create',
             contextSwitch: false,
             confidence: 1.0,
             extractedInformation: { serviceId: userMessage }
-        };
+        }];
     } else {
-        // If it's not a service ID, proceed with normal LLM-based intent analysis.
-        console.log('[Orchestrator] No service ID match. Proceeding with LLM intent analysis.');
+        console.log('[Orchestrator] No service ID match. Proceeding with intent analysis.');
         const historyForAI = mapHistoryForAI(history);
-        analyzedIntent = await analyzeConversationIntent(userMessage, historyForAI, userContext);
+        detectedIntents = await analyzeConversationIntents(userMessage, historyForAI, userContext);
     }
-    
-    console.log(`[Orchestrator] Intent Analysis Complete:`, JSON.stringify(analyzedIntent, null, 2));
+
+    primaryIntent = detectedIntents[0] || getFallbackIntent();
+
+    newStateManager.updateFromIntents(detectedIntents);
+    console.log('[Orchestrator] Active goals:', JSON.stringify(newStateManager.getGoals()));
+
+    console.log(`[Orchestrator] Intent Analysis Complete:`, JSON.stringify(detectedIntents, null, 2));
 
     // --- Unified Agent Pipeline ---
     // Instead of branching for FAQ vs. Goal, we now run a unified pipeline for every message.
@@ -109,7 +116,7 @@ export async function routeInteraction(
     // 2. Always process the state manager to understand the current task status.
     const taskContext = await processTurn(
         userContext,
-        analyzedIntent,
+        primaryIntent,
         userMessage,
         parsedMessage.businessWhatsappNumber
     );
@@ -118,7 +125,7 @@ export async function routeInteraction(
     // --- Proactive Step Logic ---
     // If the agent is about to answer a question outside of a flow, prepare the service
     // buttons and add them to the context so the agent can introduce them properly.
-    if (analyzedIntent.goalType === 'frequentlyAskedQuestion' && !taskContext.currentGoal) {
+    if (primaryIntent.goalType === 'frequentlyAskedQuestion' && !taskContext.currentGoal) {
         console.log('[Orchestrator] Proactively preparing service buttons for the agent.');
         try {
             if (services && services.length > 0) {
@@ -147,7 +154,7 @@ export async function routeInteraction(
     const validationFailureReason =
       taskContext.currentGoal?.collectedData?.validationFailureReason;
     const isNewBookingFlow =
-      analyzedIntent.goalType === 'serviceBooking' &&
+      primaryIntent.goalType === 'serviceBooking' &&
       (!userContext.currentGoal || userContext.currentGoal.currentStepIndex === 0);
 
     if (validationFailureReason === 'NOT_FOUND' && isNewBookingFlow) {

--- a/lib/conversation-engine/llm-actions/chat-interactions/functions/intention-detector.ts
+++ b/lib/conversation-engine/llm-actions/chat-interactions/functions/intention-detector.ts
@@ -1,132 +1,44 @@
-import { executeChatCompletion, OpenAIChatMessage } from "@/lib/conversation-engine/llm-actions/chat-interactions/openai-config/openai-core";
-import { UserContext } from "@/lib/database/models/user-context";
-
-
 export type GoalType = 'serviceBooking' | 'frequentlyAskedQuestion' | 'accountManagement' | 'generalChitChat' | 'unknown';
-
 export type GoalAction = 'create' | 'update' | 'delete' | 'view' | 'none';
 
 export interface AnalyzedIntent {
   goalType: GoalType;
   goalAction: GoalAction;
-  contextSwitch: boolean; // Does this message indicate a change in topic?
+  contextSwitch: boolean;
   confidence: number;
-  extractedInformation: Record<string, any>; // e.g., { "serviceName": "manicure" }
+  extractedInformation: Record<string, any>;
 }
 
+import { OpenAIChatMessage } from '@/lib/conversation-engine/llm-actions/chat-interactions/openai-config/openai-core';
+import { UserContext } from '@/lib/database/models/user-context';
+import { detectIntents } from '@agent/intent-classifier';
+
 /**
- * Analyzes the user's message in the context of the ongoing conversation to determine their intent,
- * whether they are switching topics, and extracts key information.
- *
- * @param message The user's most recent message.
- * @param history A history of the conversation messages.
- * @param userContext The current state of the user's interaction, including any active goals.
- * @returns An `AnalyzedIntent` object with the results of the analysis.
+ * Simple multi-intent analyzer that delegates to the lightweight
+ * `detectIntents` heuristics. History and userContext are currently
+ * ignored but kept for API compatibility.
  */
-export async function analyzeConversationIntent(
+export async function analyzeConversationIntents(
   message: string,
-  history: OpenAIChatMessage[],
-  userContext: UserContext | null
-): Promise<AnalyzedIntent> {
-
-  const systemPrompt = `You are a world-class conversational analyst AI. Your primary task is to analyze a user's message within the context of an ongoing conversation and provide a structured JSON output.
-
-You must answer three core questions:
-1.  **What is the user's primary goal?** (e.g., booking a service, asking a question).
-2.  **Is this goal different from the current one?** This determines if the user is switching topics.
-3.  **What specific data did the user provide?** Extract key entities like service names, dates, or questions.
-
-**Current Context:**
-The user is currently in the middle of this task:
-- Goal: ${userContext?.currentGoal?.goalType || 'none'}
-- Step: ${userContext?.currentGoal?.flowKey ? userContext.currentGoal.flowKey + ' (step ' + userContext.currentGoal.currentStepIndex + ')' : 'none'}
-- Data collected so far: ${JSON.stringify(userContext?.currentGoal?.collectedData) || '{}'}
-
-Based on this context, analyze the user's new message.
-
-**JSON Output Schema:**
-{
-  "goalType": "'serviceBooking' | 'frequentlyAskedQuestion' | 'accountManagement' | 'generalChitChat' | 'unknown'",
-  "goalAction": "'create' | 'update' | 'delete' | 'view' | 'none'",
-  "contextSwitch": "boolean // true if the new goalType is DIFFERENT from the current goal, or if the user explicitly wants to cancel/go back.",
-  "confidence": "number // 0.0 to 1.0 confidence in your analysis.",
-  "extractedInformation": "object // Key-value pairs of extracted data, e.g., {\"serviceName\": \"manicure\"} or {\"question\": \"opening hours\"}."
+  _history: OpenAIChatMessage[],
+  _userContext: UserContext | null
+): Promise<AnalyzedIntent[]> {
+  const results = detectIntents(message);
+  return results.map(intent => ({
+    goalType: intent.type as GoalType,
+    goalAction: intent.entities?.action as GoalAction || 'none',
+    contextSwitch: false,
+    confidence: 0.6,
+    extractedInformation: intent.entities || {}
+  }));
 }
 
-**Analysis Rules:**
-- **Context is King:** If the user was asked a question (e.g., 'What is your address?'), and their reply provides that info, the 'goalType' should remain the same and 'contextSwitch' must be false.
-- **Detecting a Switch:** If the current goal is 'serviceBooking' and the user suddenly asks 'What are your prices?', the 'goalType' becomes 'frequentlyAskedQuestion' and 'contextSwitch' must be true.
-- **Default to Booking:** If the current 'Goal' is 'none' (this is a new conversation), and the user's message is a greeting (hello, hi), a simple question ('how are you?'), or any non-specific opening, you **must** set the 'goalType' to 'serviceBooking' and 'goalAction' to 'create'. This is the primary entry point for the business bot.
-- **Chit-Chat During a Goal:** If there is already an active 'Goal' (e.g., user is mid-booking), and the user says 'hello', 'thanks', 'ok', etc., you should classify this as 'generalChitChat' with 'contextSwitch: false', as it does not interrupt the current flow.
-- **Implicit Intent:** A user might not state their intent directly. Infer it from their words and the context.
-- **No Data:** If no specific data is extracted, return an empty object for 'extractedInformation'.`;
-
-  const formattedHistory = history
-    .map(msg => `${msg.role}: ${msg.content}`)
-    .join('\n');
-
-  const userPrompt = `Here is the recent conversation history:
-${formattedHistory}
-
-Here is the user's new message:
-"${message}"
-
-Analyze the intent and provide the JSON output.`;
-
-  try {
-    const response = await executeChatCompletion(
-      [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
-      "gpt-4o",
-      0.2, // Low temperature for consistent JSON
-      250  // Max tokens for a structured JSON response
-    );
-
-    const resultText = response.choices[0]?.message?.content?.trim();
-    if (!resultText) {
-      console.warn('[analyzeConversationIntent] LLM returned empty content.');
-      return getFallbackIntent();
-    }
-
-    // --- New, Robust Parsing Logic ---
-    try {
-      let jsonText = resultText;
-      if (resultText.includes('```')) {
-        jsonText = resultText.substring(resultText.indexOf('{'), resultText.lastIndexOf('}') + 1);
-      }
-
-      const parsedResult = JSON.parse(jsonText) as Partial<AnalyzedIntent>;
-
-      // Validate and provide defaults for a safe return value
-      const finalIntent: AnalyzedIntent = {
-        goalType: ['serviceBooking', 'frequentlyAskedQuestion', 'accountManagement', 'generalChitChat'].includes(parsedResult.goalType as string) ? parsedResult.goalType as GoalType : 'unknown',
-        goalAction: ['create', 'update', 'delete', 'view'].includes(parsedResult.goalAction as string) ? parsedResult.goalAction as GoalAction : 'none',
-        contextSwitch: typeof parsedResult.contextSwitch === 'boolean' ? parsedResult.contextSwitch : false,
-        confidence: typeof parsedResult.confidence === 'number' ? Math.max(0, Math.min(1, parsedResult.confidence)) : 0.5,
-        extractedInformation: typeof parsedResult.extractedInformation === 'object' && parsedResult.extractedInformation !== null ? parsedResult.extractedInformation : {},
-      };
-
-      return finalIntent;
-
-    } catch (parseError) {
-      console.error('[analyzeConversationIntent] Error parsing LLM JSON response:', parseError, `Raw text: "${resultText}"`);
-      return getFallbackIntent();
-    }
-
-  } catch (error) {
-    console.error('[analyzeConversationIntent] Error during LLM call:', error);
-    return getFallbackIntent();
-  }
-}
-
-/**
- * Provides a default, safe-to-use intent object when analysis fails.
- */
-function getFallbackIntent(): AnalyzedIntent {
+export function getFallbackIntent(): AnalyzedIntent {
   return {
     goalType: 'unknown',
     goalAction: 'none',
     contextSwitch: false,
     confidence: 0,
-    extractedInformation: {},
+    extractedInformation: {}
   };
-} 
+}

--- a/src/agent/context/index.ts
+++ b/src/agent/context/index.ts
@@ -1,0 +1,18 @@
+export interface ConversationContext {
+  history: string[];
+}
+
+/**
+ * Manages retrieval and update of conversation history.
+ */
+export class ContextManager {
+  private context: ConversationContext = { history: [] };
+
+  addMessage(message: string) {
+    this.context.history.push(message);
+  }
+
+  getContext(): ConversationContext {
+    return this.context;
+  }
+}

--- a/src/agent/intent-classifier/index.ts
+++ b/src/agent/intent-classifier/index.ts
@@ -1,0 +1,38 @@
+export type IntentType =
+  | 'serviceBooking'
+  | 'frequentlyAskedQuestion'
+  | 'accountManagement'
+  | 'generalChitChat'
+  | 'unknown';
+
+export interface DetectedIntent {
+  type: IntentType;
+  entities?: Record<string, string>;
+}
+
+/**
+ * Basic rule-based multi-intent classifier used during the refactor.
+ */
+export function detectIntents(text: string): DetectedIntent[] {
+  if (!text) return [];
+  const normalized = text.toLowerCase();
+  const intents: DetectedIntent[] = [];
+
+  if (/(hi|hello|hey|thanks)/i.test(normalized)) {
+    intents.push({ type: 'generalChitChat' });
+  }
+
+  if (/(book|reserve|appointment|schedule)/i.test(normalized)) {
+    intents.push({ type: 'serviceBooking' });
+  }
+
+  if (/\?|\b(how|what|when|where|why)\b/i.test(text)) {
+    intents.push({ type: 'frequentlyAskedQuestion', entities: { question: text } });
+  }
+
+  if (intents.length === 0) {
+    intents.push({ type: 'unknown' });
+  }
+
+  return intents;
+}

--- a/src/agent/llm-response/index.ts
+++ b/src/agent/llm-response/index.ts
@@ -1,0 +1,5 @@
+export class ResponseGenerator {
+  generate(responses: string[]): string {
+    return responses.join(' ');
+  }
+}

--- a/src/agent/preprocessor/index.ts
+++ b/src/agent/preprocessor/index.ts
@@ -1,0 +1,14 @@
+export interface PreprocessedMessage {
+  raw: string;
+  normalized: string;
+}
+
+/**
+ * Prepare incoming text for downstream processing.
+ */
+export function preprocessMessage(message: string): PreprocessedMessage {
+  return {
+    raw: message,
+    normalized: message.trim().toLowerCase(),
+  };
+}

--- a/src/agent/state-manager/index.ts
+++ b/src/agent/state-manager/index.ts
@@ -1,0 +1,64 @@
+import { DetectedIntent, IntentType } from '../intent-classifier';
+
+export interface GoalSlot {
+  name: string;
+  value?: string;
+}
+
+export interface ActiveGoal {
+  type: IntentType;
+  slots: GoalSlot[];
+}
+
+/**
+ * Tracks progress of active conversation goals.
+ */
+export class DialogueStateManager {
+  private goals: ActiveGoal[] = [];
+
+  addGoal(goal: ActiveGoal) {
+    this.goals.push(goal);
+  }
+
+  updateFromIntents(intents: DetectedIntent[]) {
+    for (const intent of intents) {
+      if (intent.type === 'unknown') continue;
+      let goal = this.goals.find(g => g.type === intent.type);
+      if (!goal) {
+        goal = { type: intent.type, slots: this.createSlots(intent.type) };
+        this.goals.push(goal);
+      }
+      if (intent.entities) {
+        for (const [name, value] of Object.entries(intent.entities)) {
+          const slot = goal.slots.find(s => s.name === name);
+          if (slot) {
+            slot.value = value;
+          } else {
+            goal.slots.push({ name, value });
+          }
+        }
+      }
+    }
+  }
+
+  private createSlots(type: IntentType): GoalSlot[] {
+    switch (type) {
+      case 'serviceBooking':
+        return [
+          { name: 'service' },
+          { name: 'date' },
+          { name: 'time' },
+        ];
+      case 'frequentlyAskedQuestion':
+        return [{ name: 'question' }];
+      case 'accountManagement':
+        return [{ name: 'action' }];
+      default:
+        return [];
+    }
+  }
+
+  getGoals(): ActiveGoal[] {
+    return this.goals;
+  }
+}

--- a/src/agent/tasks/booking-intent-manager.ts
+++ b/src/agent/tasks/booking-intent-manager.ts
@@ -1,0 +1,8 @@
+import { ActiveGoal } from '../state-manager';
+
+export class BookingIntentManager {
+  handle(goal: ActiveGoal): string {
+    // TODO: booking management logic
+    return 'booking placeholder';
+  }
+}

--- a/src/agent/tasks/chitchat-responder.ts
+++ b/src/agent/tasks/chitchat-responder.ts
@@ -1,0 +1,5 @@
+export class ChitchatResponder {
+  respond(message: string): string {
+    return 'chitchat placeholder';
+  }
+}

--- a/src/agent/tasks/faq-handler.ts
+++ b/src/agent/tasks/faq-handler.ts
@@ -1,0 +1,6 @@
+export class FAQHandler {
+  answer(question: string): string {
+    // TODO: integrate RAG search
+    return 'faq placeholder';
+  }
+}

--- a/src/agent/tasks/index.ts
+++ b/src/agent/tasks/index.ts
@@ -1,0 +1,3 @@
+export * from './booking-intent-manager';
+export * from './faq-handler';
+export * from './chitchat-responder';

--- a/src/agent/whatsapp-renderer/index.ts
+++ b/src/agent/whatsapp-renderer/index.ts
@@ -1,0 +1,4 @@
+export function renderWhatsAppMessage(text: string): string {
+  // Format text for WhatsApp buttons or plain message
+  return text;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
       "@/*": ["./*"],
       "@components/*": ["components/*"],
       "@app/*": ["app/*"],
-      "@lib/*": ["lib/*"]
+      "@lib/*": ["lib/*"],
+      "@agent/*": ["src/agent/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -4,7 +4,8 @@
       "module": "commonjs",
       "baseUrl": ".",
       "paths": {
-        "@/*": ["./*"]
+        "@/*": ["./*"],
+        "@agent/*": ["src/agent/*"]
       }
     },
     "include": [


### PR DESCRIPTION
## Summary
- implement basic DialogueStateManager handling goals and slots
- log active goals from orchestrator
- document Phase 3 of the multi-intent refactor

## Testing
- `npx tsc --noEmit` *(fails to locate type declarations)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685117d08c8883228bf5c89e0bd11ab8