### PR TITLE
Add integration test for WhatsApp new user flow

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+SUPABASE_DEV_URL=https://yxavypxuzpjejkezwzjl.supabase.co
+SUPABASE_DEV_ANON_KEY=your_dev_anon_key
+SUPABASE_DEV_SERVICE_ROLE_KEY=your_dev_service_role_key
+NEXT_PUBLIC_SUPABASE_DEV_URL=https://yxavypxuzpjejkezwzjl.supabase.co
+NEXT_PUBLIC_SUPABASE_DEV_ANON_KEY=your_dev_anon_key

--- a/tests/integration/newUserFlow.test.ts
+++ b/tests/integration/newUserFlow.test.ts
@@ -1,0 +1,54 @@
+import { simulateWebhookPost } from './utils';
+import { User } from '@/lib/database/models/user';
+import { ChatSession } from '@/lib/database/models/chat-session';
+import { UserContext } from '@/lib/database/models/user-context';
+import { BOT_CONFIG } from '@/lib/bot-engine/types';
+
+describe('WhatsApp new user flow', () => {
+  const phone = '+19998887777';
+  let businessId: string | undefined;
+
+  beforeAll(async () => {
+    const existing = await User.findUserByCustomerWhatsappNumber(phone);
+    if (existing) {
+      await User.delete(existing.id);
+    }
+  });
+
+  afterAll(async () => {
+    const user = await User.findUserByCustomerWhatsappNumber(phone);
+    if (user) {
+      await User.delete(user.id);
+    }
+    if (businessId) {
+      const sessions = await ChatSession.getAll();
+      for (const s of sessions) {
+        if (s.channelUserId === phone.replace(/[^\d]/g, '')) {
+          await ChatSession.delete(s.id);
+        }
+      }
+      const ctx = await UserContext.getByChannelUserIdAndBusinessId(phone.replace(/[^\d]/g, ''), businessId);
+      if (ctx) await UserContext.delete(ctx.id);
+    }
+  });
+
+  it('creates user after collecting name', async () => {
+    const firstResp = await simulateWebhookPost({ phone, message: 'Hola' });
+    expect(JSON.stringify(firstResp)).toMatch(/nombre|llamas/i);
+
+    const session = await ChatSession.getActiveByChannelUserId('whatsapp', phone.replace(/[^\d]/g, ''), BOT_CONFIG.SESSION_TIMEOUT_HOURS);
+    expect(session).not.toBeNull();
+    if (session) {
+      businessId = session.businessId;
+      const ctx = await UserContext.getByChannelUserIdAndBusinessId(phone.replace(/[^\d]/g, ''), session.businessId);
+      expect(ctx?.sessionData?.awaitingName).toBe(true);
+    }
+
+    const secondResp = await simulateWebhookPost({ phone, message: 'TestLukitas' });
+    expect(JSON.stringify(secondResp)).toMatch(/TestLukitas/);
+
+    const created = await User.findUserByCustomerWhatsappNumber(phone);
+    expect(created).not.toBeNull();
+    expect(created?.firstName).toBe('TestLukitas');
+  });
+});

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/webhook2/route';
+import { type WebhookAPIBody } from '@/lib/bot-engine/channels/whatsapp/whatsapp-message-logger';
+
+export async function simulateWebhookPost(input: { phone: string; message: string }) {
+  const payload: WebhookAPIBody = {
+    object: 'whatsapp_business_account',
+    entry: [
+      {
+        id: 'test_entry',
+        changes: [
+          {
+            field: 'messages',
+            value: {
+              messaging_product: 'whatsapp',
+              metadata: {
+                display_phone_number: '15551890570',
+                phone_number_id: '15551890570'
+              },
+              contacts: [
+                {
+                  profile: { name: 'Test User' },
+                  wa_id: input.phone.replace(/[^\d]/g, '')
+                }
+              ],
+              messages: [
+                {
+                  from: input.phone.replace(/[^\d]/g, ''),
+                  id: `test_msg_${Date.now()}`,
+                  timestamp: Math.floor(Date.now() / 1000).toString(),
+                  text: { body: input.message },
+                  type: 'text'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  const url = 'http://localhost/api/webhook2';
+  const request = new NextRequest(
+    new Request(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  );
+
+  const res = await POST(request);
+  try {
+    return await res.json();
+  } catch {
+    return await res.text();
+  }
+}


### PR DESCRIPTION
## Summary
- add .env.test with development Supabase placeholders
- create helper to simulate webhook POST requests
- add integration test covering new user creation flow via WhatsApp

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c762ccc08322acf79bd45e2a419b