### PR TITLE
Add test db utils and example test cleanup

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,21 @@
+# Tests
+
+This folder contains integration tests and utilities.
+
+## Database utilities
+
+`tests/integration/dbUtils.ts` exposes helpers to clean the Supabase database during tests:
+
+- `deleteUserByWhatsapp(number: string)` – remove any user record matching the WhatsApp number.
+- `deleteChatSessionsForUser(number: string)` – delete chat sessions linked to that number.
+
+Use these in integration tests to ensure a fresh state before and after running scenarios.
+
+```ts
+import { deleteUserByWhatsapp, deleteChatSessionsForUser } from './integration/dbUtils';
+
+beforeAll(async () => {
+  await deleteChatSessionsForUser('+15555550123');
+  await deleteUserByWhatsapp('+15555550123');
+});
+```

--- a/tests/integration/dbUtils.ts
+++ b/tests/integration/dbUtils.ts
@@ -1,0 +1,29 @@
+import { getEnvironmentServiceRoleClient } from '@/lib/database/supabase/environment';
+
+/**
+ * Normalize a phone number for comparison by stripping non-digits.
+ */
+function normalize(number: string): string {
+  return number.replace(/[^0-9]/g, '');
+}
+
+/**
+ * Delete a user record based on their WhatsApp number.
+ */
+export async function deleteUserByWhatsapp(number: string): Promise<void> {
+  const supa = getEnvironmentServiceRoleClient();
+  const normalized = normalize(number);
+  await supa.from('users').delete().eq('whatsAppNumberNormalized', normalized);
+}
+
+/**
+ * Delete all chat sessions associated with a WhatsApp user.
+ */
+export async function deleteChatSessionsForUser(number: string): Promise<void> {
+  const supa = getEnvironmentServiceRoleClient();
+  await supa
+    .from('chatSessions')
+    .delete()
+    .eq('channel', 'whatsapp')
+    .eq('channelUserId', number);
+}

--- a/tests/integration/newUserFlow.test.ts
+++ b/tests/integration/newUserFlow.test.ts
@@ -1,0 +1,19 @@
+import { deleteUserByWhatsapp, deleteChatSessionsForUser } from './dbUtils';
+
+const TEST_WHATSAPP_NUMBER = '+15555550123';
+
+beforeAll(async () => {
+  await deleteChatSessionsForUser(TEST_WHATSAPP_NUMBER);
+  await deleteUserByWhatsapp(TEST_WHATSAPP_NUMBER);
+});
+
+afterAll(async () => {
+  await deleteChatSessionsForUser(TEST_WHATSAPP_NUMBER);
+  await deleteUserByWhatsapp(TEST_WHATSAPP_NUMBER);
+});
+
+describe('New user flow', () => {
+  it('placeholder test', async () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration utils for deleting test data
- document usage of utilities
- clear data in a placeholder new user flow test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c7ac9c38832288d0005b3cc838ac