### PR TITLE
Add integration test documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 ### 🔧 Development Workflows
 - **[Making Schema Changes](./WORKFLOW_SCHEMA_CHANGES.md)** - Step-by-step schema updates
 - **[Testing Locally](./WORKFLOW_LOCAL_TESTING.md)** - How to test WhatsApp bot locally
+- **[Running Integration Tests](../tests/README.md)** - Setup `.env.test` and run `npm test`
 - **[Troubleshooting](./TROUBLESHOOTING.md)** - Common issues and solutions
 
 ## 🎯 Quick Reference

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Running Integration Tests
+
+Integration tests verify critical flows against the development Supabase instance.
+
+## Environment variables
+Create a `.env.test` file in the project root with the following variables:
+
+```env
+SUPABASE_DEV_URL=https://your-dev-project.supabase.co
+SUPABASE_DEV_ANON_KEY=your_dev_anon_key
+SUPABASE_DEV_SERVICE_ROLE_KEY=your_dev_service_role_key
+```
+
+Additional variables required by your tests should also be added to `.env.test`.
+
+## Executing the tests
+Run the test suite with:
+
+```bash
+npm test
+```
+
+The `newUserFlow.test.ts` integration test uses the phone number `+19998887777`. After running the tests, clean up any records created for this number to keep the development database tidy.


### PR DESCRIPTION
## Summary
- document how to run integration tests
- cross-link to new guide from docs index

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868c7b128dc8322947492853a734118