### PR TITLE
Add business seeding util for integration tests

### DIFF
--- a/tests/integration/dbUtils.ts
+++ b/tests/integration/dbUtils.ts
@@ -27,3 +27,35 @@ export async function deleteChatSessionsForUser(number: string): Promise<void> {
     .eq('channel', 'whatsapp')
     .eq('channelUserId', number);
 }
+
+/**
+ * Ensure a test business exists for integration tests.
+ * Inserts a minimal WhatsApp business with a fixed ID if not present.
+ */
+export async function ensureTestBusinessExists(): Promise<void> {
+  const supa = getEnvironmentServiceRoleClient();
+  const businessId = 'test-biz';
+  const whatsappNumber = '+15551890570';
+  const phoneNumberId = '15551890570';
+
+  const { data: existing } = await supa
+    .from('businesses')
+    .select('id')
+    .eq('id', businessId)
+    .maybeSingle();
+
+  if (!existing) {
+    await supa.from('businesses').insert({
+      id: businessId,
+      name: 'Test Business',
+      email: 'test@example.com',
+      phone: whatsappNumber,
+      timeZone: 'UTC',
+      interfaceType: 'whatsapp',
+      whatsappNumber,
+      whatsappPhoneNumberId: phoneNumberId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    });
+  }
+}

--- a/tests/integration/newUserFlow.test.ts
+++ b/tests/integration/newUserFlow.test.ts
@@ -5,11 +5,16 @@ import { UserContext } from '@/lib/database/models/user-context';
 import { BOT_CONFIG } from '@/lib/bot-engine/types';
 
 // ===
-import { deleteUserByWhatsapp, deleteChatSessionsForUser } from './dbUtils';
+import {
+  deleteUserByWhatsapp,
+  deleteChatSessionsForUser,
+  ensureTestBusinessExists
+} from './dbUtils';
 
 const TEST_WHATSAPP_NUMBER = '+15555550123';
 
 beforeAll(async () => {
+  await ensureTestBusinessExists();
   await deleteChatSessionsForUser(TEST_WHATSAPP_NUMBER);
   await deleteUserByWhatsapp(TEST_WHATSAPP_NUMBER);
 });


### PR DESCRIPTION
## Summary
- add `ensureTestBusinessExists` to create a fixed WhatsApp business for tests
- invoke this helper before running the `newUserFlow` integration tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f7c73ae483228db92141f993c84d